### PR TITLE
Update ja.json and fix i18n keys

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -77,6 +77,7 @@
         "TabLabel": "Tab Label",
         "Rows": "Rows Override",
         "Columns": "Columns Override",
+        "Shared": "Shared",
         "Add": "Add"
       },
       "errors": {

--- a/src/lang/ja.json
+++ b/src/lang/ja.json
@@ -77,6 +77,7 @@
         "TabLabel": "タブの名称",
         "Rows": "行数",
         "Columns": "列数",
+        "Shared": "共有",
         "Add": "タブを追加"
       },
       "errors": {

--- a/src/module/helpers.ts
+++ b/src/module/helpers.ts
@@ -87,7 +87,7 @@ export function getUserCellConfigurationInput(
         {
           action: 'yes',
           icon: 'fas fa-check',
-          label: getLocalization().localize('Submit'),
+          label: getLocalization().localize('Save'),
           default: true,
           callback: (_event, button, dialog) => {
             const html = dialog.element;

--- a/src/templates/settings.hbs
+++ b/src/templates/settings.hbs
@@ -9,7 +9,7 @@
         <th>{{localize 'GMSCR.gridConfig.table.TabLabel'}}</th>
         <th>{{localize 'GMSCR.gridConfig.table.Columns'}}</th>
         <th>{{localize 'GMSCR.gridConfig.table.Rows'}}</th>
-        <th>{{localize 'Shared'}}</th>
+        <th>{{localize 'GMSCR.gridConfig.table.Shared'}}</th>
         <th>{{localize 'Delete'}}</th>
       </tr>
     </thead>


### PR DESCRIPTION
Updates Japanese translations and fixes translatable strings that were using non-existent Foundry Core localization keys.

- Updated `ja.json` translations
- Added `GMSCR.gridConfig.table.Shared` i18n key (Foundry Core doesn't have a "Shared" key)
- Changed "Submit" button to use Foundry Core's "Save" key instead of non-existent "Submit" key

Thank you for the maintenance and v13 support!