### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,6 +8,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/samulopez/foundryvtt-gmScreen/security/code-scanning/2](https://github.com/samulopez/foundryvtt-gmScreen/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best fix here: define workflow-level permissions right after the `on` block, since there is only one job and no job-specific elevated needs are shown. Use:

- `contents: read`

This preserves existing behavior (checkout and local npm commands still work) while preventing accidental broad token access.

Change location:
- File: `.github/workflows/pr-check.yml`
- Insert `permissions:` block between the trigger section and `jobs:`.

No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
