### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/samulopez/foundryvtt-gmScreen/security/code-scanning/1](https://github.com/samulopez/foundryvtt-gmScreen/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (best here since there is one job) to document and enforce token scope.  
For this workflow, the safest minimal functional set is:

- `contents: write` (required to create/update GitHub releases and upload release artifacts)
- optionally keep everything else implicit as `none` (GitHub default when any permissions are specified)

Edit `.github/workflows/release.yml` right after the `on:` trigger block and before `jobs:`. No imports/dependencies/methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
