### PR TITLE
fix: only toggle sidebar on initial render

### DIFF
--- a/src/module/classes/CompactJournalEntryDisplay.ts
+++ b/src/module/classes/CompactJournalEntryDisplay.ts
@@ -1,6 +1,8 @@
 export class CompactJournalEntryDisplay extends foundry.applications.sheets.journal.JournalEntrySheet {
   cellId: string;
 
+  _initialRenderDone?: boolean;
+
   constructor(options) {
     super(options);
     this.cellId = options.cellId;
@@ -37,8 +39,11 @@ export class CompactJournalEntryDisplay extends foundry.applications.sheets.jour
       gridCellContent.classList.add('gm-screen-grid-cell-content');
     }
     // incomplete type definitions
-    // @ts-expect-error
-    this.toggleSidebar();
+    if (!this._initialRenderDone) {
+      this._initialRenderDone = true;
+      // @ts-expect-error
+      this.toggleSidebar();
+    }
   }
 
   /** @override */


### PR DESCRIPTION
Currently, `toggleSidebar()` is called on every redraw of the compact journal entry display sheet. This causes the sidebar of the journal entry sheet to repeatedly toggle state or reset unexpectedly upon dynamic updates (e.g. with the WFRP 4e journal sheet). Adding a flag to restrict this toggle to the initial render fixes the issue.